### PR TITLE
feat: Add PostgreSQL support with SQLite fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,22 @@ jobs:
   backend-test:
     name: Backend Tests (pytest)
     runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: cookie_test
+          POSTGRES_USER: cookie
+          POSTGRES_PASSWORD: cookie_test  # pragma: allowlist secret
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v6
 
@@ -285,7 +301,7 @@ jobs:
             -v
         env:
           DJANGO_SETTINGS_MODULE: cookie.settings
-          DATABASE_PATH: /tmp/test_db.sqlite3
+          DATABASE_URL: postgres://cookie:cookie_test@localhost:5432/cookie_test  # pragma: allowlist secret
 
       - name: Upload backend coverage artifact
         uses: actions/upload-artifact@v6

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -28,6 +28,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libffi-dev \
+    libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install dependencies
@@ -42,6 +43,7 @@ FROM python:3.12-slim AS production
 # Install runtime dependencies including nginx and curl (for healthcheck)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi8 \
+    libpq5 \
     nginx \
     curl \
     && rm -rf /var/lib/apt/lists/* \

--- a/cookie/settings.py
+++ b/cookie/settings.py
@@ -6,6 +6,8 @@ Single settings file for simplicity.
 import os
 from pathlib import Path
 
+import dj_database_url
+
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 # ===========================================
@@ -72,28 +74,40 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "cookie.wsgi.application"
 
-# Support custom database path for Docker volumes
-DATABASE_PATH = os.environ.get("DATABASE_PATH", str(BASE_DIR / "db.sqlite3"))
+# Database configuration
+# Priority: DATABASE_URL > DATABASE_PATH > default SQLite
+DATABASE_URL = os.environ.get("DATABASE_URL")
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": DATABASE_PATH,
-        "OPTIONS": {
-            # Increase lock wait timeout from default 5s to 20s
-            "timeout": 20,
-            # Acquire write lock at transaction START (not mid-transaction)
-            # This prevents "database is locked" errors during concurrent writes
-            # by allowing failed lock acquisitions to be retried
-            "transaction_mode": "IMMEDIATE",
-            # PRAGMA settings applied on each new connection:
-            # - journal_mode=WAL: Allow concurrent reads during writes
-            # - synchronous=NORMAL: Safe for WAL mode, better performance
-            # - busy_timeout=5000: Wait up to 5s for locks at SQLite level
-            "init_command": ("PRAGMA journal_mode=WAL;PRAGMA synchronous=NORMAL;PRAGMA busy_timeout=5000;"),
-        },
+if DATABASE_URL:
+    DATABASES = {
+        "default": dj_database_url.parse(
+            DATABASE_URL,
+            conn_max_age=60,
+            conn_health_checks=True,
+        )
     }
-}
+else:
+    # SQLite fallback (existing behavior)
+    DATABASE_PATH = os.environ.get("DATABASE_PATH", str(BASE_DIR / "db.sqlite3"))
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": DATABASE_PATH,
+            "OPTIONS": {
+                # Increase lock wait timeout from default 5s to 20s
+                "timeout": 20,
+                # Acquire write lock at transaction START (not mid-transaction)
+                # This prevents "database is locked" errors during concurrent writes
+                # by allowing failed lock acquisitions to be retried
+                "transaction_mode": "IMMEDIATE",
+                # PRAGMA settings applied on each new connection:
+                # - journal_mode=WAL: Allow concurrent reads during writes
+                # - synchronous=NORMAL: Safe for WAL mode, better performance
+                # - busy_timeout=5000: Wait up to 5s for locks at SQLite level
+                "init_command": ("PRAGMA journal_mode=WAL;PRAGMA synchronous=NORMAL;PRAGMA busy_timeout=5000;"),
+            },
+        }
+    }
 
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,50 @@
+# Production deployment with PostgreSQL
+# Usage: docker compose -f docker-compose.postgres.yml up -d
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: cookie-db
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: cookie
+      POSTGRES_USER: cookie
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cookie -d cookie"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  web:
+    image: mndeaves/cookie:latest
+    container_name: cookie-web
+    restart: unless-stopped
+    ports:
+      - "80:80"
+    volumes:
+      - cookie-media:/app/data/media
+    environment:
+      - DEBUG=false
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-*}
+      - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-}
+      - DATABASE_URL=postgres://cookie:${POSTGRES_PASSWORD}@db:5432/cookie
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/api/system/health/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+volumes:
+  postgres-data:
+    name: cookie-postgres-data
+  cookie-media:
+    name: cookie-media

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  db:
+    image: postgres:16-alpine
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: cookie
+      POSTGRES_USER: cookie
+      POSTGRES_PASSWORD: cookie_dev  # pragma: allowlist secret
+    expose:
+      - "5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cookie -d cookie"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   web:
     build: .
     volumes:
@@ -8,6 +24,10 @@ services:
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=1
+      - DATABASE_URL=postgres://cookie:cookie_dev@db:5432/cookie
+    depends_on:
+      db:
+        condition: service_healthy
 
   frontend:
     image: node:20-alpine
@@ -31,3 +51,6 @@ services:
     depends_on:
       - web
       - frontend
+
+volumes:
+  postgres-data:

--- a/docs/DATABASE-MIGRATION.md
+++ b/docs/DATABASE-MIGRATION.md
@@ -1,0 +1,275 @@
+# Database Migration Guide
+
+This guide covers migrating Cookie from SQLite to PostgreSQL.
+
+## Overview
+
+Cookie supports both SQLite (default) and PostgreSQL. The database backend is selected via the `DATABASE_URL` environment variable:
+
+- **No `DATABASE_URL`**: Uses SQLite (default, backward compatible)
+- **`DATABASE_URL` set**: Uses PostgreSQL (or any Django-supported database)
+
+## Prerequisites
+
+Before migrating:
+
+1. **Backup your SQLite database**
+   ```bash
+   cp /path/to/db.sqlite3 /path/to/db.sqlite3.backup
+   ```
+
+2. **Have PostgreSQL available**
+   - Docker: Use `docker-compose.postgres.yml`
+   - Managed: AWS RDS, DigitalOcean, etc.
+   - Local: Install PostgreSQL 14+
+
+## Migration Steps
+
+### Step 1: Export Data from SQLite
+
+Export your data using Django's `dumpdata`:
+
+```bash
+# If using Docker (development)
+docker compose exec web python manage.py dumpdata \
+    --natural-foreign \
+    --natural-primary \
+    --exclude contenttypes \
+    --exclude sessions \
+    --indent 2 \
+    > data_export.json
+
+# If using production image
+docker exec cookie-web python manage.py dumpdata \
+    --natural-foreign \
+    --natural-primary \
+    --exclude contenttypes \
+    --exclude sessions \
+    --indent 2 \
+    > data_export.json
+```
+
+### Step 2: Start PostgreSQL
+
+**Option A: Development (docker-compose.yml)**
+
+The development setup already uses PostgreSQL:
+
+```bash
+docker compose up -d db
+docker compose exec db psql -U cookie -d cookie -c "SELECT 1"
+```
+
+**Option B: Production (docker-compose.postgres.yml)**
+
+```bash
+# Create .env file with password
+echo "POSTGRES_PASSWORD=your_secure_password_here" > .env
+
+# Start PostgreSQL
+docker compose -f docker-compose.postgres.yml up -d db
+
+# Verify it's running
+docker compose -f docker-compose.postgres.yml exec db \
+    psql -U cookie -d cookie -c "SELECT 1"
+```
+
+### Step 3: Run Migrations
+
+Create the database schema:
+
+```bash
+# Development
+docker compose exec web python manage.py migrate
+
+# Production
+docker compose -f docker-compose.postgres.yml exec web \
+    python manage.py migrate
+```
+
+### Step 4: Import Data
+
+Load the exported data:
+
+```bash
+# Copy export file to container
+docker cp data_export.json cookie-web:/app/data_export.json
+
+# Load data
+docker exec cookie-web python manage.py loaddata /app/data_export.json
+
+# Clean up
+docker exec cookie-web rm /app/data_export.json
+```
+
+### Step 5: Verify Migration
+
+```bash
+# Check record counts
+docker exec cookie-web python manage.py shell -c "
+from apps.recipes.models import Recipe
+from apps.profiles.models import Profile
+print(f'Recipes: {Recipe.objects.count()}')
+print(f'Profiles: {Profile.objects.count()}')
+"
+
+# Test the application
+curl http://localhost/api/system/health/
+```
+
+## Database URL Format
+
+The `DATABASE_URL` follows the standard format:
+
+```
+postgres://USER:PASSWORD@HOST:PORT/DATABASE  # pragma: allowlist secret
+```
+
+Examples:
+
+<!-- pragma: allowlist secret -->
+```bash
+# Local PostgreSQL
+DATABASE_URL=postgres://cookie:password@localhost:5432/cookie  # pragma: allowlist secret
+
+# Docker network
+DATABASE_URL=postgres://cookie:password@db:5432/cookie  # pragma: allowlist secret
+
+# AWS RDS
+DATABASE_URL=postgres://cookie:password@mydb.xxx.us-east-1.rds.amazonaws.com:5432/cookie  # pragma: allowlist secret
+
+# With SSL (managed databases)
+DATABASE_URL=postgres://cookie:password@host:5432/cookie?sslmode=require  # pragma: allowlist secret
+```
+
+## Connection Pooling
+
+The Django configuration includes:
+
+- `conn_max_age=60`: Persistent connections for 60 seconds
+- `conn_health_checks=True`: Validates connections before use
+
+For high-traffic deployments, consider PgBouncer:
+
+<!-- pragma: allowlist secret -->
+```yaml
+# docker-compose.postgres.yml addition
+pgbouncer:
+  image: edoburu/pgbouncer
+  environment:
+    DATABASE_URL: postgres://cookie:password@db:5432/cookie  # pragma: allowlist secret
+    POOL_MODE: transaction
+    MAX_CLIENT_CONN: 100
+  depends_on:
+    - db
+```
+
+## Rollback Procedure
+
+If something goes wrong, revert to SQLite:
+
+1. **Stop services**
+   ```bash
+   docker compose down
+   ```
+
+2. **Remove DATABASE_URL**
+   ```bash
+   # Edit your .env or docker-compose.yml
+   # Remove or comment out DATABASE_URL
+   ```
+
+3. **Restore SQLite backup**
+   ```bash
+   cp /path/to/db.sqlite3.backup /path/to/db.sqlite3
+   ```
+
+4. **Restart with SQLite**
+   ```bash
+   docker compose up -d
+   ```
+
+## Performance Considerations
+
+### SQLite vs PostgreSQL
+
+| Aspect | SQLite | PostgreSQL |
+|--------|--------|------------|
+| Concurrent writes | Limited (WAL helps) | Excellent |
+| Read scaling | Good | Excellent |
+| Backup | Copy file | pg_dump or WAL archiving |
+| Memory usage | Low | Higher (configurable) |
+| Setup complexity | None | Requires server |
+
+### When to Use PostgreSQL
+
+- Multiple concurrent users writing data
+- Need for replication/high availability
+- Complex queries or full-text search
+- Larger datasets (>10GB)
+
+### When SQLite is Fine
+
+- Single user or family use
+- Primarily read-heavy workloads
+- Simple deployment requirements
+- Small to medium recipe collections
+
+## Troubleshooting
+
+### Connection Refused
+
+```
+django.db.utils.OperationalError: could not connect to server
+```
+
+- Check PostgreSQL is running: `docker compose ps`
+- Verify network connectivity: `docker compose exec web ping db`
+- Check credentials in `DATABASE_URL`
+
+### Permission Denied
+
+```
+FATAL: password authentication failed for user "cookie"
+```
+
+- Verify `POSTGRES_PASSWORD` matches `DATABASE_URL`
+- Check user exists: `docker compose exec db psql -U postgres -c "\du"`
+
+### Migration Conflicts
+
+```
+django.db.utils.ProgrammingError: relation already exists
+```
+
+- Run `migrate --fake-initial` for first migration
+- Or drop and recreate database:
+  ```bash
+  docker compose exec db psql -U postgres -c "DROP DATABASE cookie;"
+  docker compose exec db psql -U postgres -c "CREATE DATABASE cookie OWNER cookie;"
+  ```
+
+### Data Import Errors
+
+```
+django.db.utils.IntegrityError: duplicate key value
+```
+
+- Ensure database is empty before import
+- Use `--natural-foreign --natural-primary` flags during export
+- Check for orphaned foreign keys in SQLite data
+
+## Security Notes
+
+- Never commit `POSTGRES_PASSWORD` to version control
+- Use environment variables or secrets management
+- Enable SSL for production connections (`?sslmode=require`)
+- Restrict PostgreSQL network access (don't expose port 5432 publicly)
+- Use strong passwords (32+ characters, random)
+
+## References
+
+- [Django Database Settings](https://docs.djangoproject.com/en/5.0/ref/settings/#databases)
+- [dj-database-url](https://github.com/jazzband/dj-database-url)
+- [PostgreSQL Docker Image](https://hub.docker.com/_/postgres)
+- [psycopg3 Documentation](https://www.psycopg.org/psycopg3/docs/)

--- a/entrypoint.prod.sh
+++ b/entrypoint.prod.sh
@@ -25,6 +25,24 @@ if [ -z "$SECRET_KEY" ]; then
     export SECRET_KEY=$(cat "$SECRET_KEY_FILE")
 fi
 
+# Wait for PostgreSQL if configured
+if [[ "$DATABASE_URL" == postgres* ]] || [[ "$DATABASE_URL" == postgresql* ]]; then
+    echo "Waiting for PostgreSQL..."
+    for i in {1..30}; do
+        if python -c "
+import django
+django.setup()
+from django.db import connection
+connection.ensure_connection()
+" 2>/dev/null; then
+            echo "PostgreSQL is ready!"
+            break
+        fi
+        echo "Waiting for database... ($i/30)"
+        sleep 2
+    done
+fi
+
 echo "Running migrations..."
 python manage.py migrate --noinput
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # Runtime dependencies
 Django>=5.0,<7.0
+dj-database-url>=2.1
+psycopg[binary]>=3.1
 gunicorn>=21.0
 django-ninja>=1.0
 Pillow>=10.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""
+Pytest configuration for Cookie tests.
+
+Ensures proper test isolation, especially for async tests that use AsyncClient.
+"""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_cached_search_images(db):
+    """
+    Clean up CachedSearchImage table before each test.
+
+    CachedSearchImage is a cache table that can accumulate entries across tests
+    when async tests use connections outside the test transaction. This fixture
+    ensures each test starts with a clean cache table.
+
+    The cleanup is fast (milliseconds) and ensures reliable test isolation.
+    """
+    from apps.recipes.models import CachedSearchImage
+
+    CachedSearchImage.objects.all().delete()
+    yield
+    # No cleanup needed after - each test gets a fresh transaction anyway

--- a/tests/test_database_config.py
+++ b/tests/test_database_config.py
@@ -1,0 +1,169 @@
+"""
+Tests for database configuration (FE-005: PostgreSQL support).
+
+These tests verify that the database configuration correctly handles:
+- DATABASE_URL environment variable (PostgreSQL)
+- SQLite fallback when DATABASE_URL is not set
+- Connection pooling settings
+
+Note: Tests avoid reloading Django settings to prevent state corruption.
+"""
+
+import os
+import pytest
+
+
+class TestDatabaseConfiguration:
+    """Tests for database configuration logic.
+
+    These tests verify the dj-database-url parsing logic directly
+    without reloading Django settings.
+    """
+
+    def test_database_url_parsing_postgres(self):
+        """Test DATABASE_URL is correctly parsed for PostgreSQL."""
+        import dj_database_url
+
+        db_config = dj_database_url.parse(
+            "postgres://user:pass@host:5432/dbname",  # pragma: allowlist secret
+            conn_max_age=60,
+            conn_health_checks=True,
+        )
+        assert db_config["ENGINE"] == "django.db.backends.postgresql"
+        assert db_config["NAME"] == "dbname"
+        assert db_config["USER"] == "user"
+        assert db_config["PASSWORD"] == "pass"  # pragma: allowlist secret
+        assert db_config["HOST"] == "host"
+        assert db_config["PORT"] == 5432
+
+    def test_database_url_parsing_postgresql_scheme(self):
+        """Test postgresql:// scheme is also accepted."""
+        import dj_database_url
+
+        db_config = dj_database_url.parse("postgresql://user:pass@host:5432/dbname")
+        assert db_config["ENGINE"] == "django.db.backends.postgresql"
+        assert db_config["NAME"] == "dbname"
+
+    def test_postgres_connection_max_age(self):
+        """Test PostgreSQL connections use persistent connections."""
+        import dj_database_url
+
+        db_config = dj_database_url.parse(
+            "postgres://user:pass@host:5432/dbname",  # pragma: allowlist secret
+            conn_max_age=60,
+        )
+        assert db_config.get("CONN_MAX_AGE") == 60
+
+    def test_postgres_connection_health_checks(self):
+        """Test PostgreSQL connections have health checks enabled."""
+        import dj_database_url
+
+        db_config = dj_database_url.parse(
+            "postgres://user:pass@host:5432/dbname",  # pragma: allowlist secret
+            conn_health_checks=True,
+        )
+        assert db_config.get("CONN_HEALTH_CHECKS") is True
+
+    def test_postgres_url_with_ssl_mode(self):
+        """Test PostgreSQL URL with SSL options."""
+        import dj_database_url
+
+        db_config = dj_database_url.parse(
+            "postgres://user:pass@host:5432/dbname?sslmode=require"  # pragma: allowlist secret
+        )
+        assert db_config["ENGINE"] == "django.db.backends.postgresql"
+        # SSL options are passed through
+        assert "sslmode" in db_config.get("OPTIONS", {}) or db_config.get("NAME") == "dbname"
+
+
+@pytest.mark.django_db
+class TestDatabaseConnection:
+    """Integration tests for database connections."""
+
+    def test_database_is_accessible(self):
+        """Test that the configured database is accessible."""
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            result = cursor.fetchone()
+            assert result[0] == 1
+
+    def test_can_create_and_query_records(self, db):
+        """Test basic CRUD operations work with the database."""
+        from apps.profiles.models import Profile
+
+        # Create
+        profile = Profile.objects.create(name="Test User", avatar_color="#123456")
+        assert profile.id is not None
+
+        # Read
+        fetched = Profile.objects.get(id=profile.id)
+        assert fetched.name == "Test User"
+
+        # Update
+        fetched.name = "Updated User"
+        fetched.save()
+        fetched.refresh_from_db()
+        assert fetched.name == "Updated User"
+
+        # Delete
+        fetched.delete()
+        assert Profile.objects.filter(id=profile.id).count() == 0
+
+    def test_database_vendor_matches_config(self):
+        """Test database vendor matches expected based on configuration."""
+        from django.db import connection
+
+        vendor = connection.vendor
+
+        if os.environ.get("DATABASE_URL"):
+            # If DATABASE_URL is set, should be PostgreSQL
+            assert vendor == "postgresql"
+        else:
+            # Otherwise should be SQLite
+            assert vendor == "sqlite"
+
+    def test_migrations_are_applied(self):
+        """Test that all migrations have been applied."""
+        from django.core.management import call_command
+        from io import StringIO
+
+        out = StringIO()
+        call_command("showmigrations", "--plan", stdout=out)
+        output = out.getvalue()
+
+        # All migrations should be marked as applied (with [X])
+        unapplied = [line for line in output.split("\n") if line.strip().startswith("[ ]")]
+        assert len(unapplied) == 0, f"Unapplied migrations: {unapplied}"
+
+
+@pytest.mark.django_db
+class TestPostgresSpecificFeatures:
+    """Tests for PostgreSQL-specific behavior (skipped if using SQLite)."""
+
+    @pytest.fixture(autouse=True)
+    def skip_if_sqlite(self):
+        """Skip these tests if not using PostgreSQL."""
+        from django.db import connection
+
+        if connection.vendor != "postgresql":
+            pytest.skip("PostgreSQL-specific test")
+
+    def test_jsonfield_native_support(self, db):
+        """Test JSONField works with native PostgreSQL JSON support."""
+        from apps.recipes.models import Recipe
+        from apps.profiles.models import Profile
+
+        profile = Profile.objects.create(name="Test User")
+        recipe = Recipe.objects.create(
+            profile=profile,
+            title="JSON Test Recipe",
+            host="test.com",
+            ingredients=["ingredient 1", "ingredient 2"],
+            instructions=["step 1", "step 2"],
+        )
+
+        # Query using JSON field
+        fetched = Recipe.objects.get(id=recipe.id)
+        assert fetched.ingredients == ["ingredient 1", "ingredient 2"]

--- a/tests/test_system_api.py
+++ b/tests/test_system_api.py
@@ -109,9 +109,11 @@ def populated_database(db, test_profile):
         notes=["Double the baking time"],
     )
 
-    # Create cached search image
+    # Create cached search image with unique URL to avoid conflicts
+    import uuid
+
     cached_image = CachedSearchImage.objects.create(
-        external_url="https://example.com/image.jpg",
+        external_url=f"https://example.com/system-api-test-{uuid.uuid4()}.jpg",
         status=CachedSearchImage.STATUS_SUCCESS,
     )
 
@@ -146,7 +148,7 @@ class TestHealthCheck:
 class TestResetPreview:
     """Tests for GET /api/system/reset-preview/"""
 
-    def test_preview_empty_database(self, client):
+    def test_preview_empty_database(self, client, db):
         """Test preview with empty database returns zero counts."""
         response = client.get("/api/system/reset-preview/")
         assert response.status_code == 200
@@ -154,6 +156,7 @@ class TestResetPreview:
         data = response.json()
         counts = data["data_counts"]
 
+        # These should be zero in a fresh database transaction
         assert counts["profiles"] == 0
         assert counts["recipes"] == 0
         assert counts["recipe_images"] == 0
@@ -183,7 +186,7 @@ class TestResetPreview:
         assert counts["serving_adjustments"] == 1
         assert counts["cached_search_images"] == 1
 
-    def test_preview_returns_preserved_items(self, client):
+    def test_preview_returns_preserved_items(self, client, db):
         """Test preview lists items that will be preserved."""
         response = client.get("/api/system/reset-preview/")
         assert response.status_code == 200
@@ -195,7 +198,7 @@ class TestResetPreview:
         assert "AI prompt templates" in preserved
         assert "Application settings" in preserved
 
-    def test_preview_returns_warnings(self, client):
+    def test_preview_returns_warnings(self, client, db):
         """Test preview includes safety warnings."""
         response = client.get("/api/system/reset-preview/")
         assert response.status_code == 200


### PR DESCRIPTION
Add PostgreSQL as the primary database backend while maintaining backward compatibility with SQLite for simple deployments.

Changes:
- Add dj-database-url and psycopg3 dependencies
- Configure settings.py to use DATABASE_URL env var for PostgreSQL
- Update docker-compose.yml to use PostgreSQL in development
- Add docker-compose.postgres.yml for production PostgreSQL setup
- Update Dockerfile.prod with PostgreSQL client libraries
- Add wait-for-postgres logic in entrypoint.prod.sh
- Update CI to run tests against PostgreSQL
- Add database configuration tests
- Add migration guide documentation

Test isolation fixes:
- Add tests/conftest.py to clean CachedSearchImage between tests
- Fix test_system_api.py fixtures for proper async test isolation