### PR TITLE
fix(auth): prevent X-Forwarded-For injection bypass in rate limit IP resolution

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -7,24 +7,41 @@ from django.http import JsonResponse
 
 
 def get_client_ip(request):
-    """Extract the real client IP from X-Forwarded-For for django-ratelimit.
+    """Extract the real client IP for django-ratelimit.
 
-    X-Forwarded-For may contain multiple IPs: "client, proxy1, proxy2".
-    We take the leftmost entry (the original client), validate it as a
-    real IP address, and return it.  Falls back to REMOTE_ADDR if the
-    header is missing or every entry is malformed.
+    Priority order:
+    1. CF-Connecting-IP — set authoritatively by Cloudflare to the real client
+       IP.  Cloudflare strips any client-injected CF-Connecting-IP header
+       before appending its own, so this value cannot be spoofed.
+    2. Rightmost X-Forwarded-For entry — when CF-Connecting-IP is absent
+       (e.g. local dev, direct traffic) we use the rightmost entry, which is
+       appended by the nearest trusted proxy and is harder to spoof than the
+       leftmost entry.  The leftmost entry is attacker-controlled: Cloudflare
+       appends the real IP but does NOT strip client-injected entries.
+    3. REMOTE_ADDR — final fallback.
 
     Used via RATELIMIT_IP_META_KEY = "apps.core.middleware.get_client_ip"
     """
-    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
-    if forwarded_for:
-        # Take the leftmost (client) IP, strip whitespace
-        candidate = forwarded_for.split(",")[0].strip()
+    # Primary: CF-Connecting-IP (Cloudflare strips client-provided values)
+    cf_ip = request.META.get("HTTP_CF_CONNECTING_IP", "").strip()
+    if cf_ip:
         try:
-            ipaddress.ip_address(candidate)
-            return candidate
+            ipaddress.ip_address(cf_ip)
+            return cf_ip
         except ValueError:
             pass
+
+    # Fallback: rightmost X-Forwarded-For entry (nearest trusted proxy)
+    forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if forwarded_for:
+        entries = [e.strip() for e in forwarded_for.split(",")]
+        for candidate in reversed(entries):
+            try:
+                ipaddress.ip_address(candidate)
+                return candidate
+            except ValueError:
+                continue
+
     return request.META.get("REMOTE_ADDR", "127.0.0.1")
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -13,7 +13,13 @@ from apps.core.middleware import (
 
 
 class TestGetClientIp:
-    """Test IP extraction from X-Forwarded-For for rate limiting."""
+    """Test IP extraction for rate limiting.
+
+    Priority: CF-Connecting-IP > rightmost X-Forwarded-For > REMOTE_ADDR.
+    CF-Connecting-IP is set authoritatively by Cloudflare; clients cannot
+    inject fake values.  The leftmost X-Forwarded-For entry is attacker-
+    controlled and must NOT be used.
+    """
 
     def _make_request(self, **meta):
         rf = RequestFactory()
@@ -21,25 +27,73 @@ class TestGetClientIp:
         request.META.update(meta)
         return request
 
-    def test_single_ip(self):
+    # --- CF-Connecting-IP (primary source) ---
+
+    def test_cf_connecting_ip_used_when_present(self):
+        """CF-Connecting-IP wins over any X-Forwarded-For value."""
+        request = self._make_request(
+            HTTP_CF_CONNECTING_IP="1.2.3.4",
+            HTTP_X_FORWARDED_FOR="5.6.7.8, 172.18.0.1",
+        )
+        assert get_client_ip(request) == "1.2.3.4"
+
+    def test_cf_connecting_ip_ipv6(self):
+        request = self._make_request(HTTP_CF_CONNECTING_IP="2a09:bac3:3759:278::3f:dd")
+        assert get_client_ip(request) == "2a09:bac3:3759:278::3f:dd"
+
+    def test_cf_connecting_ip_malformed_falls_through(self):
+        """If CF-Connecting-IP is somehow malformed, fall back to XFF."""
+        request = self._make_request(
+            HTTP_CF_CONNECTING_IP="not-an-ip",
+            HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1",
+            REMOTE_ADDR="10.0.0.5",
+        )
+        # Should land on rightmost valid XFF entry, not REMOTE_ADDR
+        assert get_client_ip(request) == "172.18.0.1"
+
+    # --- X-Forwarded-For fallback (rightmost valid entry) ---
+
+    def test_xff_rightmost_used_without_cf_header(self):
+        """Without CF-Connecting-IP, use rightmost XFF (nearest trusted proxy)."""
+        request = self._make_request(HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1, 172.18.0.2")
+        assert get_client_ip(request) == "172.18.0.2"
+
+    def test_xff_single_entry(self):
         request = self._make_request(HTTP_X_FORWARDED_FOR="192.168.1.1")
         assert get_client_ip(request) == "192.168.1.1"
 
-    def test_multi_proxy_chain(self):
-        request = self._make_request(HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1, 172.18.0.2")
-        assert get_client_ip(request) == "81.141.119.30"
-
-    def test_ipv6(self):
+    def test_xff_ipv6_rightmost(self):
         request = self._make_request(HTTP_X_FORWARDED_FOR="2a09:bac3:3759:278::3f:dd, 172.18.0.1")
-        assert get_client_ip(request) == "2a09:bac3:3759:278::3f:dd"
+        assert get_client_ip(request) == "172.18.0.1"
+
+    def test_xff_spoofing_bypass_prevented(self):
+        """Core security regression: attacker injects a fake leftmost entry.
+        Cloudflare appends the real IP but does NOT strip the injected entry.
+        The fix must return the real (rightmost) IP, not the spoofed leftmost."""
+        request = self._make_request(
+            HTTP_X_FORWARDED_FOR="1.1.1.1, 5.5.5.5",  # 1.1.1.1 is attacker-injected
+        )
+        # Real client IP is 5.5.5.5 (appended by Cloudflare)
+        assert get_client_ip(request) == "5.5.5.5"
+        assert get_client_ip(request) != "1.1.1.1"
+
+    def test_xff_skips_malformed_entries_from_right(self):
+        """Malformed rightmost entries are skipped; search continues leftward."""
+        request = self._make_request(
+            HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1, bad-entry",
+            REMOTE_ADDR="10.0.0.9",
+        )
+        assert get_client_ip(request) == "172.18.0.1"
+
+    def test_xff_all_malformed_falls_back_to_remote_addr(self):
+        request = self._make_request(HTTP_X_FORWARDED_FOR="not-an-ip, also-bad", REMOTE_ADDR="172.18.0.2")
+        assert get_client_ip(request) == "172.18.0.2"
+
+    # --- REMOTE_ADDR fallback ---
 
     def test_no_forwarded_for_uses_remote_addr(self):
         request = self._make_request(REMOTE_ADDR="10.0.0.1")
         assert get_client_ip(request) == "10.0.0.1"
-
-    def test_malformed_ip_falls_back(self):
-        request = self._make_request(HTTP_X_FORWARDED_FOR="not-an-ip, 172.18.0.1", REMOTE_ADDR="172.18.0.2")
-        assert get_client_ip(request) == "172.18.0.2"
 
     def test_empty_forwarded_for(self):
         request = self._make_request(HTTP_X_FORWARDED_FOR="", REMOTE_ADDR="127.0.0.1")


### PR DESCRIPTION
## Summary

- Change `get_client_ip()` to use `CF-Connecting-IP` as the primary source for IP-based rate limiting
- `CF-Connecting-IP` is set authoritatively by Cloudflare and clients cannot inject fake values (Cloudflare strips client-provided values before appending its own)
- Previous leftmost X-Forwarded-For approach was bypassable: Cloudflare appends the real IP but does NOT strip client-injected XFF entries, so an attacker could prepend `1.2.3.4` to XFF and bypass django-ratelimit entirely
- Fallback chain: CF-Connecting-IP → rightmost X-Forwarded-For (nearest trusted proxy) → REMOTE_ADDR
- Updated test suite: 12 focused tests covering CF-Connecting-IP priority, rightmost-XFF selection, spoofing bypass regression, and malformed-entry handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)