### PR TITLE
fix(auth): remove CF-Connecting-IP from get_client_ip (F-26)

### DIFF
--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -9,29 +9,20 @@ from django.http import JsonResponse
 def get_client_ip(request):
     """Extract the real client IP for django-ratelimit.
 
-    Priority order:
-    1. CF-Connecting-IP — set authoritatively by Cloudflare to the real client
-       IP.  Cloudflare strips any client-injected CF-Connecting-IP header
-       before appending its own, so this value cannot be spoofed.
-    2. Rightmost X-Forwarded-For entry — when CF-Connecting-IP is absent
-       (e.g. local dev, direct traffic) we use the rightmost entry, which is
-       appended by the nearest trusted proxy and is harder to spoof than the
-       leftmost entry.  The leftmost entry is attacker-controlled: Cloudflare
-       appends the real IP but does NOT strip client-injected entries.
-    3. REMOTE_ADDR — final fallback.
+    Uses rightmost X-Forwarded-For entry as the authoritative source:
+    - Cloudflare strips any client-injected X-Forwarded-For entries and
+      appends the real client IP; Traefik trusts Cloudflare's XFF via
+      forwardedHeaders.trustedIPs, so the rightmost entry is always the
+      real client IP as seen by Cloudflare.
+    - REMOTE_ADDR is the final fallback for local dev / direct traffic.
+
+    CF-Connecting-IP was intentionally removed (pentest round 10, F-26):
+    Cloudflare does NOT strip client-injected CF-Connecting-IP headers
+    before adding its own — an attacker can inject an arbitrary value and
+    bypass rate limiting entirely.  Do NOT re-add CF-Connecting-IP.
 
     Used via RATELIMIT_IP_META_KEY = "apps.core.middleware.get_client_ip"
     """
-    # Primary: CF-Connecting-IP (Cloudflare strips client-provided values)
-    cf_ip = request.META.get("HTTP_CF_CONNECTING_IP", "").strip()
-    if cf_ip:
-        try:
-            ipaddress.ip_address(cf_ip)
-            return cf_ip
-        except ValueError:
-            pass
-
-    # Fallback: rightmost X-Forwarded-For entry (nearest trusted proxy)
     forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
     if forwarded_for:
         entries = [e.strip() for e in forwarded_for.split(",")]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -15,10 +15,11 @@ from apps.core.middleware import (
 class TestGetClientIp:
     """Test IP extraction for rate limiting.
 
-    Priority: CF-Connecting-IP > rightmost X-Forwarded-For > REMOTE_ADDR.
-    CF-Connecting-IP is set authoritatively by Cloudflare; clients cannot
-    inject fake values.  The leftmost X-Forwarded-For entry is attacker-
-    controlled and must NOT be used.
+    Source: rightmost X-Forwarded-For > REMOTE_ADDR.
+    CF-Connecting-IP was removed (pentest round 10, F-26): Cloudflare does NOT
+    strip client-injected CF-Connecting-IP headers, making it injectable for
+    rate-limit bypass.  XFF is safe because Cloudflare strips client-injected
+    XFF entries and appends the real client IP as the rightmost entry.
     """
 
     def _make_request(self, **meta):
@@ -27,34 +28,24 @@ class TestGetClientIp:
         request.META.update(meta)
         return request
 
-    # --- CF-Connecting-IP (primary source) ---
+    # --- CF-Connecting-IP must NOT influence result (F-26 regression guard) ---
 
-    def test_cf_connecting_ip_used_when_present(self):
-        """CF-Connecting-IP wins over any X-Forwarded-For value."""
+    def test_cf_connecting_ip_injection_does_not_bypass(self):
+        """F-26 regression: injecting CF-Connecting-IP must not affect the result.
+        Cloudflare does NOT strip client-provided CF-Connecting-IP headers, so
+        we must ignore it entirely and rely solely on XFF."""
         request = self._make_request(
-            HTTP_CF_CONNECTING_IP="1.2.3.4",
+            HTTP_CF_CONNECTING_IP="198.51.100.1",  # attacker-injected
             HTTP_X_FORWARDED_FOR="5.6.7.8, 172.18.0.1",
         )
-        assert get_client_ip(request) == "1.2.3.4"
-
-    def test_cf_connecting_ip_ipv6(self):
-        request = self._make_request(HTTP_CF_CONNECTING_IP="2a09:bac3:3759:278::3f:dd")
-        assert get_client_ip(request) == "2a09:bac3:3759:278::3f:dd"
-
-    def test_cf_connecting_ip_malformed_falls_through(self):
-        """If CF-Connecting-IP is somehow malformed, fall back to XFF."""
-        request = self._make_request(
-            HTTP_CF_CONNECTING_IP="not-an-ip",
-            HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1",
-            REMOTE_ADDR="10.0.0.5",
-        )
-        # Should land on rightmost valid XFF entry, not REMOTE_ADDR
+        # Must return rightmost XFF, not the injected CF-Connecting-IP value
         assert get_client_ip(request) == "172.18.0.1"
+        assert get_client_ip(request) != "198.51.100.1"
 
-    # --- X-Forwarded-For fallback (rightmost valid entry) ---
+    # --- X-Forwarded-For (rightmost valid entry) ---
 
-    def test_xff_rightmost_used_without_cf_header(self):
-        """Without CF-Connecting-IP, use rightmost XFF (nearest trusted proxy)."""
+    def test_xff_rightmost_used(self):
+        """Rightmost XFF entry (appended by Cloudflare) is the authoritative IP."""
         request = self._make_request(HTTP_X_FORWARDED_FOR="81.141.119.30, 172.18.0.1, 172.18.0.2")
         assert get_client_ip(request) == "172.18.0.2"
 


### PR DESCRIPTION
Pentest round 10 finding: CF-Connecting-IP is injectable by clients — Cloudflare does not strip it. Rightmost XFF is the correct approach.