### PR TITLE
feat: pull-to-refresh + hide unit toggle + buildx v4 bump

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -57,7 +57,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
@@ -116,7 +116,7 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0

--- a/apps/legacy/static/legacy/css/components.css
+++ b/apps/legacy/static/legacy/css/components.css
@@ -1060,3 +1060,59 @@
     color: #6b6560;
     font-size: 0.875rem;
 }
+
+/* Pull-to-refresh indicator */
+.ptr-indicator {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 9000;
+    pointer-events: none;
+    -webkit-justify-content: center;
+    justify-content: center;
+    -webkit-transform: translateY(0);
+    transform: translateY(0);
+}
+
+.ptr-indicator-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: #ffffff;
+    border: 1px solid #e8e1d8;
+    -webkit-box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+    margin-top: 8px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%236b8e5f' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><polyline points='23 4 23 10 17 10'/><polyline points='1 20 1 14 7 14'/><path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15'/></svg>");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 22px 22px;
+    -webkit-transition: -webkit-transform 0.05s linear;
+    transition: transform 0.05s linear;
+}
+
+.ptr-indicator-ready .ptr-indicator-icon {
+    border-color: #6b8e5f;
+}
+
+.ptr-indicator-releasing .ptr-indicator-icon {
+    -webkit-animation: ptr-spin 0.8s linear infinite;
+    animation: ptr-spin 0.8s linear infinite;
+}
+
+@-webkit-keyframes ptr-spin {
+    from { -webkit-transform: rotate(0deg); }
+    to { -webkit-transform: rotate(360deg); }
+}
+
+@keyframes ptr-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+html.dark .ptr-indicator-icon {
+    background-color: #1f1c19;
+    border-color: #3a3531;
+}

--- a/apps/legacy/static/legacy/js/pages/settings-general.js
+++ b/apps/legacy/static/legacy/js/pages/settings-general.js
@@ -12,8 +12,6 @@
     var saveKeyText;
     var themeLightBtn;
     var themeDarkBtn;
-    var unitsMetricBtn;
-    var unitsImperialBtn;
     var quotaConfigSection;
     var quotaUsageSection;
     var saveQuotasBtn;
@@ -27,8 +25,6 @@
         saveKeyText = document.getElementById('save-key-text');
         themeLightBtn = document.getElementById('theme-light-btn');
         themeDarkBtn = document.getElementById('theme-dark-btn');
-        unitsMetricBtn = document.getElementById('units-metric-btn');
-        unitsImperialBtn = document.getElementById('units-imperial-btn');
         quotaConfigSection = document.getElementById('quota-config-section');
         quotaUsageSection = document.getElementById('quota-usage-section');
         saveQuotasBtn = document.getElementById('save-quotas-btn');
@@ -48,12 +44,6 @@
         }
         if (themeDarkBtn) {
             themeDarkBtn.addEventListener('click', handleThemeClick);
-        }
-        if (unitsMetricBtn) {
-            unitsMetricBtn.addEventListener('click', handleUnitsClick);
-        }
-        if (unitsImperialBtn) {
-            unitsImperialBtn.addEventListener('click', handleUnitsClick);
         }
         if (saveQuotasBtn) {
             saveQuotasBtn.addEventListener('click', handleSaveQuotas);
@@ -127,11 +117,6 @@
         savePreference('theme', newTheme);
     }
 
-    function handleUnitsClick(e) {
-        var newUnit = e.currentTarget.getAttribute('data-unit');
-        savePreference('unit_preference', newUnit);
-    }
-
     function savePreference(field, value) {
         var pageEl = document.querySelector('[data-page="settings"]');
         var profileId = pageEl ? pageEl.getAttribute('data-profile-id') : null;
@@ -152,10 +137,6 @@
                 applyTheme(value);
                 if (profile) profile.theme = value;
                 Cookie.toast.success('Theme updated');
-            } else if (field === 'unit_preference') {
-                setToggleActive(unitsMetricBtn, unitsImperialBtn, value === 'metric');
-                if (profile) profile.unit_preference = value;
-                Cookie.toast.success('Units updated');
             }
         });
     }

--- a/apps/legacy/static/legacy/js/pull-to-refresh.js
+++ b/apps/legacy/static/legacy/js/pull-to-refresh.js
@@ -1,0 +1,154 @@
+/**
+ * Pull-to-refresh (ES5, iOS 9 compatible).
+ *
+ * Listens for vertical drags from the top of the page. When the page is
+ * already scrolled to the top, dragging down past PULL_THRESHOLD reloads
+ * the current page. Used by iOS standalone (Add to Home Screen) installs
+ * where the system rubber-band doesn't trigger a real refresh.
+ *
+ * Safety:
+ *   - aborts if the touch starts inside an input/textarea/[contenteditable]
+ *   - aborts if any scrollable ancestor of the touch target has scrollTop>0
+ *   - aborts on multi-touch
+ *   - feature-detects passive listeners (iOS 9 doesn't support the options
+ *     object — passing one would be parsed as useCapture=true)
+ */
+(function() {
+    'use strict';
+
+    if (!('ontouchstart' in window)) return;
+
+    var PULL_THRESHOLD = 70;
+    var ACTIVATION_DISTANCE = 10;
+    var MAX_PULL = PULL_THRESHOLD * 1.6;
+
+    var startY = null;
+    var distance = 0;
+    var pulling = false;
+    var releasing = false;
+    var indicator;
+    var icon;
+
+    // Feature-detect passive listeners (iOS 9.3 lacks support).
+    var supportsPassive = false;
+    try {
+        var opts = Object.defineProperty({}, 'passive', {
+            get: function() { supportsPassive = true; return false; }
+        });
+        window.addEventListener('test-passive', null, opts);
+        window.removeEventListener('test-passive', null, opts);
+    } catch (e) {}
+
+    function isAtTop() {
+        var sy = window.pageYOffset || document.documentElement.scrollTop || 0;
+        return sy <= 0;
+    }
+
+    function hasScrolledScrollableAncestor(target) {
+        var node = target;
+        while (node && node !== document.body && node !== document.documentElement) {
+            var style = window.getComputedStyle ? window.getComputedStyle(node) : node.currentStyle;
+            if (style) {
+                var overflowY = style.overflowY;
+                if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight) {
+                    if (node.scrollTop > 0) return true;
+                }
+            }
+            node = node.parentNode;
+        }
+        return false;
+    }
+
+    function ensureIndicator() {
+        if (indicator) return;
+        indicator = document.getElementById('ptr-indicator');
+        if (!indicator) {
+            indicator = document.createElement('div');
+            indicator.id = 'ptr-indicator';
+            indicator.className = 'ptr-indicator';
+            indicator.setAttribute('aria-hidden', 'true');
+            icon = document.createElement('div');
+            icon.className = 'ptr-indicator-icon';
+            indicator.appendChild(icon);
+            document.body.appendChild(indicator);
+        } else {
+            icon = indicator.querySelector('.ptr-indicator-icon');
+        }
+    }
+
+    function render() {
+        ensureIndicator();
+        if (!pulling && !releasing) {
+            indicator.style.display = 'none';
+            indicator.className = 'ptr-indicator';
+            return;
+        }
+        indicator.style.display = 'flex';
+        var translateY = releasing ? 24 : Math.min(distance * 0.6, 48);
+        indicator.style.webkitTransform = 'translateY(' + translateY + 'px)';
+        indicator.style.transform = 'translateY(' + translateY + 'px)';
+        var ready = distance >= PULL_THRESHOLD;
+        indicator.className = 'ptr-indicator' + (ready ? ' ptr-indicator-ready' : '') + (releasing ? ' ptr-indicator-releasing' : '');
+        if (icon && !releasing) {
+            var rot = Math.min(1, distance / PULL_THRESHOLD) * 270;
+            icon.style.webkitTransform = 'rotate(' + rot + 'deg)';
+            icon.style.transform = 'rotate(' + rot + 'deg)';
+        }
+    }
+
+    function reset() {
+        startY = null;
+        distance = 0;
+        pulling = false;
+        render();
+    }
+
+    function onTouchStart(e) {
+        if (releasing) return;
+        if (!e.touches || e.touches.length !== 1) return;
+        if (!isAtTop()) return;
+        var target = e.target;
+        if (!target) return;
+        // closest is polyfilled in legacy/polyfills.js for iOS 9.
+        if (target.closest && target.closest('input, textarea, select, [contenteditable="true"], [data-no-ptr]')) return;
+        if (hasScrolledScrollableAncestor(target)) return;
+        startY = e.touches[0].clientY;
+    }
+
+    function onTouchMove(e) {
+        if (startY === null) return;
+        if (!e.touches || e.touches.length !== 1) {
+            reset();
+            return;
+        }
+        var dy = e.touches[0].clientY - startY;
+        if (dy <= 0) {
+            reset();
+            return;
+        }
+        if (dy < ACTIVATION_DISTANCE) return;
+        if (e.cancelable) e.preventDefault();
+        distance = Math.min(dy, MAX_PULL);
+        pulling = true;
+        render();
+    }
+
+    function onTouchEnd() {
+        if (pulling && distance >= PULL_THRESHOLD) {
+            releasing = true;
+            render();
+            // Brief frame for the user to see the spinner state before reload.
+            setTimeout(function() { window.location.reload(); }, 80);
+            return;
+        }
+        reset();
+    }
+
+    var moveOpts = supportsPassive ? { passive: false } : false;
+    var passiveOpts = supportsPassive ? { passive: true } : false;
+
+    document.addEventListener('touchstart', onTouchStart, passiveOpts);
+    document.addEventListener('touchmove', onTouchMove, moveOpts);
+    document.addEventListener('touchend', onTouchEnd, passiveOpts);
+    document.addEventListener('touchcancel', reset, passiveOpts);
+})();

--- a/apps/legacy/templates/legacy/base.html
+++ b/apps/legacy/templates/legacy/base.html
@@ -33,6 +33,7 @@
     <script src="{% static 'legacy/js/toast.js' %}"></script>
     <script src="{% static 'legacy/js/ai-error.js' %}"></script>
     <script src="{% static 'legacy/js/utils.js' %}"></script>
+    <script src="{% static 'legacy/js/pull-to-refresh.js' %}"></script>
     <script src="{% static 'legacy/js/app.js' %}"></script>
     {% block extra_js %}{% endblock %}
 </body>

--- a/apps/legacy/templates/legacy/settings.html
+++ b/apps/legacy/templates/legacy/settings.html
@@ -98,18 +98,6 @@
             </div>
             {% endif %}
 
-            <!-- Preferences (all users) -->
-            <div class="card mt-4">
-                <h2 class="settings-section-title">Preferences</h2>
-                <div class="form-group form-group-inline">
-                    <span class="form-label">Units</span>
-                    <div class="pref-btn-group">
-                        <button type="button" id="units-metric-btn" class="pref-toggle{% if profile.unit_preference != 'imperial' %} active{% endif %}" data-unit="metric">Metric</button>
-                        <button type="button" id="units-imperial-btn" class="pref-toggle{% if profile.unit_preference == 'imperial' %} active{% endif %}" data-unit="imperial">Imperial</button>
-                    </div>
-                </div>
-            </div>
-
             {% if is_admin %}
             <!-- AI Quota Config (admin, passkey mode only — hidden by default, shown by JS) -->
             <div id="quota-config-section" class="card mt-4 hidden">

--- a/apps/profiles/api.py
+++ b/apps/profiles/api.py
@@ -89,9 +89,13 @@ class PreferencesIn(Schema):
     """Display-preference payload for per-profile self-updates in both modes.
 
     Separated from ProfileIn so passkey-mode users can change their own theme
-    and unit_preference without touching identity fields (name, avatar_color)
-    which remain HomeOnly. Every field is optional — only sent fields are
-    written, so PATCH with {"theme": "dark"} leaves unit_preference alone.
+    without touching identity fields (name, avatar_color) which remain
+    HomeOnly. Every field is optional — only sent fields are written, so
+    PATCH with {"theme": "dark"} is a noop on other fields.
+
+    Note: unit_preference is accepted to preserve API back-compat for older
+    clients but the endpoint rejects writes (feature disabled in v1.64). The
+    underlying column remains for read-only consumers (AI scaling).
     """
 
     theme: Optional[str] = None
@@ -214,19 +218,20 @@ def update_preferences(request, profile_id: int, payload: PreferencesIn):
     if not caller_profile or caller_profile.id != profile_id:
         return Status(403, {"error": "forbidden", "message": "Cannot modify another profile"})
 
-    # Validate allowed values. Reject unknown theme/unit strings — no free-form input.
+    # Reject unit_preference writes — UI toggle hidden in v1.64 because conversion
+    # is only wired into AI scaling, not recipe display / scrape / cook mode.
+    if payload.unit_preference is not None:
+        return Status(
+            400,
+            {"error": "feature_disabled", "message": "unit_preference is not currently configurable"},
+        )
+
+    # Validate allowed values. Reject unknown theme strings — no free-form input.
     updates: dict[str, str] = {}
     if payload.theme is not None:
         if payload.theme not in ("light", "dark"):
             return Status(400, {"error": "validation_error", "message": "theme must be 'light' or 'dark'"})
         updates["theme"] = payload.theme
-    if payload.unit_preference is not None:
-        if payload.unit_preference not in ("metric", "imperial"):
-            return Status(
-                400,
-                {"error": "validation_error", "message": "unit_preference must be 'metric' or 'imperial'"},
-            )
-        updates["unit_preference"] = payload.unit_preference
 
     if not updates:
         # Nothing sent — return current profile, don't touch the DB.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,7 +24,7 @@ services:
       retries: 5
 
   web:
-    image: ghcr.io/matthewdeaves/cookie:1.67.2
+    image: ghcr.io/matthewdeaves/cookie:1.68.0
     container_name: cookie-prod
     ports:
       - "80:80"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,14 @@
 import { RouterProvider } from 'react-router-dom'
 import { router } from './router'
+import PullToRefresh from './components/PullToRefresh'
 
 function App() {
-  return <RouterProvider router={router} />
+  return (
+    <>
+      <PullToRefresh />
+      <RouterProvider router={router} />
+    </>
+  )
 }
 
 export default App

--- a/frontend/src/components/PullToRefresh.tsx
+++ b/frontend/src/components/PullToRefresh.tsx
@@ -1,0 +1,28 @@
+import { RefreshCw } from 'lucide-react'
+import { usePullToRefresh } from '../hooks/usePullToRefresh'
+
+export default function PullToRefresh() {
+  const { pullDistance, isPulling, isReleasing, threshold } = usePullToRefresh()
+
+  if (!isPulling && !isReleasing) return null
+
+  const progress = Math.min(1, pullDistance / threshold)
+  const willRefresh = pullDistance >= threshold
+  const translateY = isReleasing ? 24 : Math.min(pullDistance * 0.6, 48)
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-x-0 top-0 z-50 flex justify-center"
+      style={{ transform: `translateY(${translateY}px)`, transition: isReleasing ? 'transform 80ms ease-out' : 'none' }}
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-full border border-border bg-background/95 shadow-md backdrop-blur">
+        <RefreshCw
+          className={isReleasing ? 'h-5 w-5 animate-spin text-primary' : 'h-5 w-5 text-foreground/70'}
+          style={{ transform: isReleasing ? undefined : `rotate(${progress * 270}deg)`, opacity: 0.5 + progress * 0.5 }}
+        />
+      </div>
+      <span className="sr-only">{willRefresh ? 'Release to refresh' : 'Pull to refresh'}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/SettingsGeneral.tsx
+++ b/frontend/src/components/settings/SettingsGeneral.tsx
@@ -28,7 +28,7 @@ export default function SettingsGeneral({
   quotaData,
   onQuotaSave,
 }: SettingsGeneralProps) {
-  const { profile, theme, toggleTheme, updateUnitPreference } = useProfile()
+  const { profile, theme, toggleTheme } = useProfile()
   const auth = useOptionalAuth()
   const logout = auth?.logout
   const mode = useMode()
@@ -41,7 +41,7 @@ export default function SettingsGeneral({
         <h2 className="mb-4 text-lg font-medium text-foreground">Preferences</h2>
 
         {/* Theme toggle */}
-        <div className="mb-4">
+        <div>
           <label className="mb-2 block text-sm font-medium text-foreground">Theme</label>
           <div className="flex gap-2">
             <button
@@ -67,35 +67,6 @@ export default function SettingsGeneral({
             >
               <Moon className="h-4 w-4" />
               Dark
-            </button>
-          </div>
-        </div>
-
-        {/* Unit preference */}
-        <div>
-          <label className="mb-2 block text-sm font-medium text-foreground">Units</label>
-          <div className="flex gap-2">
-            <button
-              onClick={() => profile?.unit_preference !== 'metric' && updateUnitPreference('metric')}
-              className={cn(
-                'rounded-lg border px-4 py-2 text-sm font-medium transition-colors',
-                profile?.unit_preference !== 'imperial'
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-background text-foreground hover:bg-muted'
-              )}
-            >
-              Metric
-            </button>
-            <button
-              onClick={() => profile?.unit_preference !== 'imperial' && updateUnitPreference('imperial')}
-              className={cn(
-                'rounded-lg border px-4 py-2 text-sm font-medium transition-colors',
-                profile?.unit_preference === 'imperial'
-                  ? 'border-primary bg-primary text-primary-foreground'
-                  : 'border-border bg-background text-foreground hover:bg-muted'
-              )}
-            >
-              Imperial
             </button>
           </div>
         </div>

--- a/frontend/src/contexts/ProfileContext.tsx
+++ b/frontend/src/contexts/ProfileContext.tsx
@@ -11,7 +11,6 @@ interface ProfileContextType {
   selectProfile: (profile: Profile) => Promise<void>
   logout: () => void
   toggleTheme: () => Promise<void>
-  updateUnitPreference: (unit: 'metric' | 'imperial') => Promise<void>
   toggleFavorite: (recipe: RecipeDetail) => Promise<void>
   isFavorite: (recipeId: number) => boolean
 }
@@ -84,24 +83,11 @@ export function ProfileProvider({ children, authProfile, onProfileSelected }: Pr
     }
   }, [profile, theme, setProfile, setTheme])
 
-  const updateUnitPreference = useCallback(async (unit: 'metric' | 'imperial') => {
-    if (!profile) return
-    const previousUnit = profile.unit_preference
-    setProfile({ ...profile, unit_preference: unit })
-    try {
-      const updated = await api.profiles.updatePreferences(profile.id, { unit_preference: unit })
-      setProfile(updated)
-    } catch (error) {
-      console.error('Failed to update unit preference:', error)
-      setProfile({ ...profile, unit_preference: previousUnit })
-    }
-  }, [profile, setProfile])
-
   return (
     <ProfileContext.Provider
       value={{
         profile, theme, favoriteRecipeIds, loading,
-        selectProfile, logout, toggleTheme, updateUnitPreference,
+        selectProfile, logout, toggleTheme,
         toggleFavorite, isFavorite,
       }}
     >

--- a/frontend/src/hooks/usePullToRefresh.ts
+++ b/frontend/src/hooks/usePullToRefresh.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react'
+
+const PULL_THRESHOLD = 70
+const ACTIVATION_DISTANCE = 10
+const MAX_PULL = PULL_THRESHOLD * 1.6
+
+function isAtTop(): boolean {
+  return window.scrollY <= 0 && document.documentElement.scrollTop <= 0
+}
+
+// If the user starts the gesture inside an internal scroller that is not at
+// scrollTop 0, we must not hijack it for refresh — scrolling within the
+// scroller stays a normal scroll.
+function hasScrolledScrollableAncestor(target: Element | null): boolean {
+  let node: Element | null = target
+  while (node && node !== document.body && node !== document.documentElement) {
+    const style = window.getComputedStyle(node)
+    const overflowY = style.overflowY
+    if ((overflowY === 'auto' || overflowY === 'scroll') && node.scrollHeight > node.clientHeight) {
+      if (node.scrollTop > 0) return true
+    }
+    node = node.parentElement
+  }
+  return false
+}
+
+export interface PullToRefreshState {
+  pullDistance: number
+  isPulling: boolean
+  isReleasing: boolean
+  threshold: number
+}
+
+export function usePullToRefresh(): PullToRefreshState {
+  const [pullDistance, setPullDistance] = useState(0)
+  const [isPulling, setIsPulling] = useState(false)
+  const [isReleasing, setIsReleasing] = useState(false)
+
+  const startYRef = useRef<number | null>(null)
+  const distanceRef = useRef(0)
+  const pullingRef = useRef(false)
+
+  useEffect(() => {
+    function reset() {
+      startYRef.current = null
+      distanceRef.current = 0
+      pullingRef.current = false
+      setPullDistance(0)
+      setIsPulling(false)
+    }
+
+    function onTouchStart(e: TouchEvent) {
+      if (e.touches.length !== 1) return
+      if (!isAtTop()) return
+      const target = e.target as Element | null
+      if (!target) return
+      if (target.closest('input, textarea, select, [contenteditable="true"], [data-no-ptr]')) return
+      if (hasScrolledScrollableAncestor(target)) return
+      startYRef.current = e.touches[0].clientY
+    }
+
+    function onTouchMove(e: TouchEvent) {
+      if (startYRef.current === null) return
+      if (e.touches.length !== 1) {
+        reset()
+        return
+      }
+      const dy = e.touches[0].clientY - startYRef.current
+      if (dy <= 0) {
+        reset()
+        return
+      }
+      if (dy < ACTIVATION_DISTANCE) return
+      // Block native rubber-band so the indicator owns the gesture.
+      if (e.cancelable) e.preventDefault()
+      const visible = Math.min(dy, MAX_PULL)
+      distanceRef.current = visible
+      pullingRef.current = true
+      setPullDistance(visible)
+      setIsPulling(true)
+    }
+
+    function onTouchEnd() {
+      if (pullingRef.current && distanceRef.current >= PULL_THRESHOLD) {
+        // Show the "releasing" state briefly so the user gets visual confirmation
+        // before the page reloads. setTimeout lets React paint one frame.
+        setIsReleasing(true)
+        setTimeout(() => window.location.reload(), 80)
+        return
+      }
+      reset()
+    }
+
+    document.addEventListener('touchstart', onTouchStart, { passive: true })
+    document.addEventListener('touchmove', onTouchMove, { passive: false })
+    document.addEventListener('touchend', onTouchEnd, { passive: true })
+    document.addEventListener('touchcancel', reset, { passive: true })
+
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart)
+      document.removeEventListener('touchmove', onTouchMove as EventListener)
+      document.removeEventListener('touchend', onTouchEnd)
+      document.removeEventListener('touchcancel', reset as EventListener)
+    }
+  }, [])
+
+  return { pullDistance, isPulling, isReleasing, threshold: PULL_THRESHOLD }
+}

--- a/tests/test_profiles_preferences_api.py
+++ b/tests/test_profiles_preferences_api.py
@@ -61,16 +61,23 @@ class TestUpdatePreferences:
         assert response.status_code == 200
         assert response.json()["theme"] == "dark"
 
-    def test_passkey_mode_unit_preference(self, client, settings):
+    def test_unit_preference_writes_disabled(self, client, settings):
+        """v1.64+: unit_preference UI is hidden because conversion is only wired
+        into AI scaling, not display/scrape/cook. The endpoint rejects writes to
+        prevent silent partial behavior. Stored value (default 'metric') is
+        preserved for the AI scaling read-path."""
         settings.AUTH_MODE = "passkey"
         user = _create_user("imperial")
         _login(client, user)
         response = self._patch(client, user.profile.id, {"unit_preference": "imperial"})
-        assert response.status_code == 200
-        assert response.json()["unit_preference"] == "imperial"
+        assert response.status_code == 400
+        assert response.json()["error"] == "feature_disabled"
+        user.profile.refresh_from_db()
+        assert user.profile.unit_preference == "metric"  # stored value untouched
 
-    def test_combined_theme_and_unit(self, client, settings):
-        """Single PATCH updates both fields atomically."""
+    def test_combined_payload_rejected_when_unit_set(self, client, settings):
+        """If a payload includes unit_preference alongside theme, the whole
+        request is rejected — theme must NOT be partially applied. Atomic."""
         settings.AUTH_MODE = "passkey"
         user = _create_user("both")
         _login(client, user)
@@ -79,10 +86,9 @@ class TestUpdatePreferences:
             user.profile.id,
             {"theme": "dark", "unit_preference": "imperial"},
         )
-        assert response.status_code == 200
-        data = response.json()
-        assert data["theme"] == "dark"
-        assert data["unit_preference"] == "imperial"
+        assert response.status_code == 400
+        user.profile.refresh_from_db()
+        assert user.profile.theme == "light"  # unchanged — not partially applied
 
     def test_cross_profile_forbidden(self, client, settings):
         """Callers may only modify their OWN profile. No cross-user update."""
@@ -106,13 +112,6 @@ class TestUpdatePreferences:
         user = _create_user("t1")
         _login(client, user)
         response = self._patch(client, user.profile.id, {"theme": "rainbow"})
-        assert response.status_code == 400
-
-    def test_invalid_unit_rejected(self, client, settings):
-        settings.AUTH_MODE = "passkey"
-        user = _create_user("t2")
-        _login(client, user)
-        response = self._patch(client, user.profile.id, {"unit_preference": "cubits"})
         assert response.status_code == 400
 
     def test_cannot_change_name_via_preferences(self, client, settings):


### PR DESCRIPTION
## Summary

Three concerns bundled for the v1.64 release. Each is a self-contained logical commit.

### 1. Pull-to-refresh on both frontends

iOS standalone (Add to Home Screen) doesn't trigger a real refresh on the system rubber-band. Adds a real PTR gesture on both frontends.

- **Modern**: ``usePullToRefresh`` hook + ``<PullToRefresh />`` indicator mounted at the app root. Document-level touch listeners. Threshold 70px → ``location.reload()``.
- **Legacy (ES5, iOS 9.3)**: ``pull-to-refresh.js`` registered after ``utils.js``. Feature-detects passive-listener support (iOS 9 lacks it; passing the options object would be parsed as ``useCapture=true``). Indicator styled with ``-webkit-`` + standard transforms only.

**Safety gates (both)**:
- Only fires when ``window.scrollY === 0``.
- Aborts if the touch starts inside an input/textarea/select/[contenteditable] or any element with ``data-no-ptr``.
- Walks ancestors to abort if any scrollable ancestor has ``scrollTop > 0`` — modals with internal scroll won't accidentally refresh.
- Aborts on multi-touch.

### 2. Hide unit toggle + reject preference writes

Audit found the metric/imperial toggle was only honored by the AI scaling endpoint (``apps/ai/services/scaling.py:130``); recipe display, scrape, and cook mode all ignored it. To avoid silent partial behavior, the toggle is hidden in both UIs and the API now rejects writes with ``400 feature_disabled``.

- Stored ``unit_preference`` column is **preserved** so the AI scaling read-path keeps working with each profile's existing value.
- ``PreferencesIn`` schema still accepts the field (back-compat) but the endpoint rejects.
- If a payload contains both ``theme`` and ``unit_preference``, the whole request is rejected — no partial application. Test added.

### 3. CI: ``docker/setup-buildx-action`` v3 → v4.0.0

Drop-in bump (we use no deprecated inputs). Both call sites in ``cd.yml`` updated with new pinned SHA.

## Test plan

- [x] ``ruff check`` green on changed Python.
- [x] Frontend ``eslint .`` and ``tsc --noEmit`` green.
- [x] Vitest: 517 / 517 passing locally.
- [x] ``pytest tests/test_profiles_preferences_api.py`` passes (10 tests, including new disabled-write coverage).
- [ ] Full CI run on this branch.
- [ ] iPhone PWA standalone smoke: pull down on Home, Detail, Search → refreshes.
- [ ] iPad iOS 9.3 legacy smoke: pull down on Home → refreshes; modal scroll does not trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)