### PR TITLE
fix(security): force letter prefix in passkey profile name suffix

### DIFF
--- a/apps/core/passkey_api.py
+++ b/apps/core/passkey_api.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import secrets
+import string
 import time
 import uuid
 
@@ -170,9 +172,14 @@ def _create_passkey_user_and_profile(verification, transports=None):
     user.set_unusable_password()
     user.save(update_fields=["password"])
 
+    # First char is forced to a letter so the suffix can never collapse to all
+    # digits. uuid.uuid4().hex[:6] is hex (0-9a-f) — ~5.6% of draws are all
+    # digits, which then matches `^User \d+$` and trips R23's "user count
+    # leak" guard. The remaining 5 hex chars carry the entropy.
+    suffix = secrets.choice(string.ascii_lowercase) + uuid.uuid4().hex[:5]
     profile = Profile.objects.create(
         user=user,
-        name=f"User {uuid.uuid4().hex[:6]}",
+        name=f"User {suffix}",
         avatar_color=Profile.next_avatar_color(),
     )
 


### PR DESCRIPTION
## Summary

CI on master flaked at commit ``1e93a4d8`` (PR #110 squash merge) — ``test_profile_name_does_not_reveal_user_count`` produced ``User 600536``, matching the R23 guard regex ``^User \d+\$``.

## Root cause

``apps/core/passkey_api.py`` builds the profile name as ``f\"User {uuid.uuid4().hex[:6]}\"``. ``uuid.uuid4().hex`` is hex (``0-9a-f``); 6 chars are all digits with probability ``(10/16)^6 ≈ 5.6%`` (1 in 18). Whenever the unlucky draw lands, the test fails.

## Fix

Prefix the suffix with one ``secrets.choice(string.ascii_lowercase)`` letter, then 5 hex chars. The suffix can never be purely numeric, so the test is deterministic. Entropy on the random 5 chars is ample for the ``test_profile_name_has_random_suffix`` uniqueness assertion (collision rate ``~1/16^5 ≈ 1 in 1M``).

## Test plan

- [x] ``pytest tests/test_passkey_api_r23.py`` — all 5 tests pass.
- [ ] Full CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)