### PR TITLE
fix(discover): fall back to cached suggestions when refresh quota exhausted

### DIFF
--- a/apps/ai/api_discover.py
+++ b/apps/ai/api_discover.py
@@ -80,6 +80,11 @@ def discover_endpoint(request, profile_id: int, refresh: bool = False):
     if not has_cached:
         allowed, info = reserve_quota(profile, "discover")
         if not allowed:
+            # Quota exhausted — fall back to cached suggestions if available (e.g. refresh requested but already refreshed today)
+            fallback = AIDiscoverySuggestion.objects.filter(profile=profile, created_at__gte=cache_cutoff).exists()
+            if fallback:
+                result = get_discover_suggestions(profile_id, force_refresh=False)
+                return result
             return Status(429, {"error": "quota_exceeded", "message": "Daily limit reached for discover", **info})
 
     try:

--- a/tests/test_ai_discover.py
+++ b/tests/test_ai_discover.py
@@ -447,3 +447,48 @@ def test_format_suggestions_from_list(profile):
     assert len(result["suggestions"]) == 1
     assert result["suggestions"][0]["type"] == "new"
     assert result["suggestions"][0]["title"] == "New Thing"
+
+
+# --- Quota exhausted fallback ---
+
+
+@pytest.mark.django_db
+def test_discover_refresh_quota_exhausted_falls_back_to_cache(auth_client, profile):
+    """When refresh=true but quota is exhausted, serve cached suggestions (200) instead of 429."""
+    # Create a cached suggestion within the 24h window
+    AIDiscoverySuggestion.objects.create(
+        profile=profile,
+        suggestion_type="seasonal",
+        title="Cached Spring Salad",
+        description="A fresh spring salad",
+        search_query="spring salad recipes",
+    )
+
+    # Quota is exhausted
+    with patch(
+        "apps.ai.api_discover.reserve_quota",
+        return_value=(False, {"remaining": 0, "limit": 1}),
+    ):
+        response = auth_client.get(f"/api/ai/discover/{profile.id}/?refresh=true")
+
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert len(data["suggestions"]) == 1
+    assert data["suggestions"][0]["title"] == "Cached Spring Salad"
+    assert "refreshed_at" in data
+
+
+@pytest.mark.django_db
+def test_discover_refresh_quota_exhausted_no_cache_returns_429(auth_client, profile):
+    """When refresh=true, quota is exhausted, and no cache exists, return 429."""
+    # No cached suggestions — table is empty for this profile
+
+    with patch(
+        "apps.ai.api_discover.reserve_quota",
+        return_value=(False, {"remaining": 0, "limit": 1}),
+    ):
+        response = auth_client.get(f"/api/ai/discover/{profile.id}/?refresh=true")
+
+    assert response.status_code == 429
+    data = json.loads(response.content)
+    assert data["error"] == "quota_exceeded"


### PR DESCRIPTION
When refresh=True is requested and the daily quota is exhausted, serve cached suggestions (within 24h window) instead of returning 429. Only 429 when there is genuinely nothing cached.

Regression test: test_discover_refresh_quota_exhausted_falls_back_to_cache (and test_discover_refresh_quota_exhausted_no_cache_returns_429).

Fixes: clicking regenerate on the Discover tab when quota is spent now shows existing suggestions instead of an error.